### PR TITLE
chore(deps): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+---
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps-actions)
+    labels: [deps, ci]
+    groups:
+      gha-minor-and-patch:
+        update-types: [minor, patch]
+  # Python (pip)
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps-pip)
+    labels: [deps, python, prod]
+    groups:
+      pip-runtime-minor-patch:
+        patterns: ['*']
+        update-types: [minor, patch]
+  # npm PROD (dependencies)
+  - package-ecosystem: npm
+    directory: /app/frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    commit-message:
+      prefix: chore(deps-npm:prod)
+    labels: [deps, js, ts, frontend, prod]
+    allow:
+      - dependency-type: production
+    groups:
+      npm-prod-minor-and-patch:
+        update-types: [minor, patch]
+  # npm DEV (devDependencies)
+  - package-ecosystem: npm
+    directory: /app/frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    commit-message:
+      prefix: chore(deps-npm:dev)
+    labels: [deps, js, ts, frontend, dev]
+    allow:
+      - dependency-type: development
+    groups:
+      npm-dev-minor-and-patch:
+        update-types: [minor, patch]
+      npm-dev-major:
+        update-types: [major]


### PR DESCRIPTION
Добавил еженедельные обновления зависимостей через Dependabot с раздельными потоками для трёх экосистем: GitHub Actions, Python (pip) и npm (фронтенд в app/frontend), с разделением конфигов там, где это возможно

⚙️ GitHub Actions

  - Minor/Patch обновления собираются в единый групповой PR (gha-minor-and-patch)
  - Major обновления идут отдельными PR по каждому экшену


🐍 Python (pip)

  Источник: корневой requirements.txt

  - Minor/Patch объединяются в один PR (pip-runtime-minor-patch)
  - Major — отдельными PR по пакетам


📦 npm (frontend: app/frontend)
  

-   Prod (dependencies):

  
    - Minor/Patch — один групповой PR (npm-prod-minor-and-patch)
    - Major — отдельными PR
  

-   Dev (devDependencies):

  
    - Minor/Patch — один групповой PR (npm-dev-minor-and-patch)
    - Major — одним батч-PR (npm-dev-major) для всех dev-зависимостей (требование по задаче)

fyi @fey