### PR TITLE
Configure CSRF_TRUSTED_ORIGINS environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 SECRET_KEY=your_secret_key
 DJANGO_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 ALLOWED_HOSTS=127.0.0.1,localhost,yourdomain.com
+CSRF_TRUSTED_ORIGINS=http://localhost:5173,https://yourdomain.com
 
 EMAIL_HOST=smtp.example.com
 EMAIL_PORT=587

--- a/app/settings.py
+++ b/app/settings.py
@@ -227,6 +227,14 @@ INERTIA_LAYOUT = BASE_DIR / "app" / "templates" / "index.html"
 CSRF_HEADER_NAME = "HTTP_X_XSRF_TOKEN"
 CSRF_COOKIE_NAME = "XSRF-TOKEN"
 
+# Trusted sources (scheme + host) for CSRF checks on cross-domain requests
+raw_csrf_trusted_origins = os.getenv("CSRF_TRUSTED_ORIGINS", "")
+CSRF_TRUSTED_ORIGINS = [
+    origin.strip()
+    for origin in raw_csrf_trusted_origins.split(",")
+    if origin.strip()
+]
+
 # Password reset
 EMAIL_FOR_PASSWORD_RESET = os.environ.get("EMAIL_FOR_PASSWORD_RESET", "")
 PASSWORD_RESET_TIMEOUT = os.environ.get("PASSWORD_RESET_TIMEOUT", 3600)


### PR DESCRIPTION
**Issues:** #217 

- Добавила CSRF_TRUSTED_ORIGINS в .env.example (схема + хост)
- Переменная считывается в app/settings.py (строки 231-236) и разбивается по запятой
- При пустом значении, список будет пустым

