### PR TITLE
fixed bug 216 in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,4 @@ AI_API_KEY=your_ai_key
 AI_API_MODEL=your_ai_model
 AI_API_TIMEOUT=your_ai_timeout
 
-CHAT_MAX_HISTORY_LENGHT=your_max_history_lenght
+CHAT_MAX_HISTORY_LENGTH=your_max_history_length


### PR DESCRIPTION
- исправлена опечатка в .env.example
- переменная переименована с CHAT_MAX_HISTORY_LENGHT на CHAT_MAX_HISTORY_LENGTH